### PR TITLE
Generate ATA and close ATA in `jupiterIxToHawksight` ix

### DIFF
--- a/hawk-api/package.json
+++ b/hawk-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hawksightco/hawk-sdk",
-  "version": "1.1.19",
+  "version": "1.1.20",
   "description": "Hawksight v2 SDK",
   "main": "dist/src/index.js",
   "repository": "https://github.com/ghabxph/hawk-api-client.git",

--- a/hawk-api/package.json
+++ b/hawk-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hawksightco/hawk-sdk",
-  "version": "1.1.20",
+  "version": "1.1.21",
   "description": "Hawksight v2 SDK",
   "main": "dist/src/index.js",
   "repository": "https://github.com/ghabxph/hawk-api-client.git",

--- a/hawk-api/src/classes/JupiterSwap.ts
+++ b/hawk-api/src/classes/JupiterSwap.ts
@@ -1,6 +1,7 @@
 import * as web3 from "@solana/web3.js";
 import { SimpleIxGenerator } from "./SimpleIxGenerator";
 import BN from "bn.js";
+import { JupiterRouteIxReturn } from '../ixGenerator/IyfMainIxGenerator';
 
 type JupiterIxToHawksight = {
   connection: web3.Connection,
@@ -8,6 +9,7 @@ type JupiterIxToHawksight = {
   quotedOutAmountOverride?: BN,
   slippageBpsOverride?: number,
   platformFeeBpsOverride?: number,
+  checkDestinationTokenAccount?: boolean,
 };
 
 export class JupiterSwap {
@@ -16,7 +18,7 @@ export class JupiterSwap {
     private ix: SimpleIxGenerator,
   ){}
 
-  async jupiterIxToHawksight({connection, swapInstruction, quotedOutAmountOverride, slippageBpsOverride, platformFeeBpsOverride}: JupiterIxToHawksight): Promise<web3.TransactionInstruction> {
+  async jupiterIxToHawksight({connection, swapInstruction, quotedOutAmountOverride, slippageBpsOverride, platformFeeBpsOverride, checkDestinationTokenAccount}: JupiterIxToHawksight): Promise<JupiterRouteIxReturn> {
     return await this.ix.iyfMain.jupiterRouteIx({
       connection,
       userPda: swapInstruction.keys[1].pubkey,
@@ -30,6 +32,7 @@ export class JupiterSwap {
       quotedOutAmount: quotedOutAmountOverride,
       slippageBps: slippageBpsOverride,
       platformFeeBps: platformFeeBpsOverride,
-    })
+      checkDestinationTokenAccount,
+    });
   }
 }

--- a/hawk-api/src/idl/iyf-main-idl.ts
+++ b/hawk-api/src/idl/iyf-main-idl.ts
@@ -6416,6 +6416,53 @@ export type IndexYieldFarming = {
           "type": "u8"
         }
       ]
+    },
+    {
+      "name": "closeAta",
+      "accounts": [
+        {
+          "name": "userPda",
+          "isMut": false,
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "multi-user"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "UserAccountMulti",
+                "path": "user_pda.farm"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "UserAccountMulti",
+                "path": "user_pda.authority"
+              }
+            ]
+          }
+        },
+        {
+          "name": "hsAuthority",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "userTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
     }
   ],
   "accounts": [
@@ -13447,6 +13494,53 @@ export const IDL: IndexYieldFarming = {
           "type": "u8"
         }
       ]
+    },
+    {
+      "name": "closeAta",
+      "accounts": [
+        {
+          "name": "userPda",
+          "isMut": false,
+          "isSigner": false,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "type": "string",
+                "value": "multi-user"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "UserAccountMulti",
+                "path": "user_pda.farm"
+              },
+              {
+                "kind": "account",
+                "type": "publicKey",
+                "account": "UserAccountMulti",
+                "path": "user_pda.authority"
+              }
+            ]
+          }
+        },
+        {
+          "name": "hsAuthority",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "userTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": []
     }
   ],
   "accounts": [

--- a/hawk-api/test/classes/JupiterSwap.spec.ts
+++ b/hawk-api/test/classes/JupiterSwap.spec.ts
@@ -20,7 +20,12 @@ describe('SimpleIxGenerator: Jupiter Route IX Tests', () => {
       connection,
       swapInstruction: new web3.TransactionInstruction({
         programId: web3.SystemProgram.programId,
-        keys: new Array(20).fill({ pubkey: web3.SystemProgram.programId, isSigner: false, isWritable: false }),
+        keys: [
+          { pubkey: web3.SystemProgram.programId, isSigner: false, isWritable: false },
+          { pubkey: web3.SystemProgram.programId, isSigner: false, isWritable: false },
+          { pubkey: web3.SystemProgram.programId, isSigner: false, isWritable: false },
+          { pubkey: new web3.PublicKey('2a8MS8dWyyYNgBHgtzeTwrsDKsE6RnCoUqnonB4C8Xc3'), isSigner: false, isWritable: false },
+          ...new Array(16).fill({ pubkey: web3.SystemProgram.programId, isSigner: false, isWritable: false })],
         data: Buffer.from([
           0xe5, 0x17, 0xcb, 0x97, 0x7a, 0xe3, 0xad, 0x2a, 0x01, 0x00, 0x00, 0x00, 0x3a, 0x00, 0x64, 0x00,
           0x01, 0x8e, 0xdf, 0x1e, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x46, 0xf2, 0x9f, 0x39, 0x00, 0x00, 0x00,

--- a/hawk-api/test/classes/SimpleIxGenerator.spec.ts
+++ b/hawk-api/test/classes/SimpleIxGenerator.spec.ts
@@ -277,7 +277,7 @@ describe('SimpleIxGenerator: Jupiter Route IX Tests', () => {
         connection,
         userWallet,
         sourceTokenAccount: web3.SystemProgram.programId,
-        destinationTokenAccount: web3.SystemProgram.programId,
+        destinationTokenAccount: new web3.PublicKey('2a8MS8dWyyYNgBHgtzeTwrsDKsE6RnCoUqnonB4C8Xc3'),
         destinationMint: web3.SystemProgram.programId,
         platformFeeAccount: web3.SystemProgram.programId,
         eventAuthority: web3.SystemProgram.programId,


### PR DESCRIPTION
# Generate ATA and close ATA in `jupiterIxToHawksight` ix

Generates create ATA and close ATA instruction within `jupiterIxToHawksight` method

## Changes

- Changed return value of `jupiterIxToHawksight` method (breaking change)

## Type of change

Please select options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Add new / change in documentation
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Code style update (formatting, local variables)
- [ ] CI related changes
- [ ] Other (please describe):

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

## Test screenshots / Test Logs

https://github.com/hawksightco/hs-dapp/pull/3150

## Relevant check-items prior to deployment

- [ ] #3150 deployed and merged to mainnet
- [ ] Revision requests @enzoampil  / @mikeejazmines 
- [x] Bump `hawk-api` version and publish to NPM
- [ ] Merge to main
